### PR TITLE
feat: add an API for enforcing the stub id and an option to disable serving the homepage

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -104,6 +104,8 @@ interface StudioTransactionRequest {
 }
 type StudioRequest = StudioQueryRequest | StudioTransactionRequest;
 interface StudioOptions {
+    enforceId?: string;
+    serveHomepage?: boolean;
     basicAuth?: {
         username: string;
         password: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -105,7 +105,7 @@ interface StudioTransactionRequest {
 type StudioRequest = StudioQueryRequest | StudioTransactionRequest;
 interface StudioOptions {
     enforceId?: string;
-    serveHomepage?: boolean;
+    disableHomepage?: boolean;
     basicAuth?: {
         username: string;
         password: string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -331,8 +331,11 @@ export async function studio(request, doNamespace, options) {
     if (request.method === 'GET') {
         // This is where we render the interface
         const url = new URL(request.url);
-        const stubId = url.searchParams.get('id');
+        const stubId = options?.enforceId ?? url.searchParams.get('id');
         if (!stubId) {
+            if (options?.serveHomepage === false) {
+                return new Response('Not found', { status: 404 });
+            }
             return new Response(createHomepageInterface(), { headers: { 'Content-Type': 'text/html' } });
         }
         return new Response(createStudioInterface(stubId), { headers: { 'Content-Type': 'text/html' } });
@@ -340,7 +343,8 @@ export async function studio(request, doNamespace, options) {
     else if (request.method === 'POST') {
         const body = (await request.json());
         if (body.type === 'query' || body.type === 'transaction') {
-            const stubId = doNamespace.idFromName(body.id);
+            const id = options?.enforceId ?? body.id;
+            const stubId = doNamespace.idFromName(id);
             const stub = doNamespace.get(stubId);
             try {
                 // @ts-ignore - accessing __studio method that we know exists

--- a/dist/index.js
+++ b/dist/index.js
@@ -333,7 +333,7 @@ export async function studio(request, doNamespace, options) {
         const url = new URL(request.url);
         const stubId = options?.enforceId ?? url.searchParams.get('id');
         if (!stubId) {
-            if (options?.serveHomepage === false) {
+            if (options?.disableHomepage) {
                 return new Response('Not found', { status: 404 });
             }
             return new Response(createHomepageInterface(), { headers: { 'Content-Type': 'text/html' } });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@outerbase/browsable-durable-object",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "type": "module",
     "module": "./dist/index.js",
     "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,7 +397,7 @@ function createStudioInterface(stubId: string) {
 
 interface StudioOptions {
         enforceId?: string;
-        serveHomepage?: boolean;
+        disableHomepage?: boolean;
 	basicAuth?: {
 		username: string;
 		password: string;
@@ -438,7 +438,7 @@ export async function studio(request: Request, doNamespace: DurableObjectNamespa
 		const stubId = options?.enforceId ?? url.searchParams.get('id');
 
 		if (!stubId) {
-                        if (options?.serveHomepage === false) {
+                        if (options?.disableHomepage) {
                             return new Response('Not found', { status: 404 });
                         }
 			return new Response(createHomepageInterface(), { headers: { 'Content-Type': 'text/html' } });


### PR DESCRIPTION
On my app, i serve outerbase studio on an authenticated route and have a tenant of sqlite-in-do for each customer, and this way i can enforce the client cannot change the DO id and see another people data without needing to re-build the request into a sanitized one or something like that.